### PR TITLE
Update Zig repository link to Codeberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ N/A
 ## Zig
 
 * main: https://ziglang.org
-* repo: https://github.com/ziglang/zig
+* repo: https://codeberg.org/ziglang/zig
 * documentation:
   - https://ziglang.org/documentation/master/
 * discussion:


### PR DESCRIPTION
Zig moved to Codeberg https://ziglang.org/news/migrating-from-github-to-codeberg/